### PR TITLE
Add reaction() utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### :rocket: Enhancement
+* `signal-utils`
+  * [#61](https://github.com/proposal-signals/signal-utils/pull/61) Add `reaction()` function to run effects when watched values change.
+
 ## Release (2024-04-22)
 
 signal-utils 0.15.0 (minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-#### :rocket: Enhancement
-* `signal-utils`
-  * [#61](https://github.com/proposal-signals/signal-utils/pull/61) Add `reaction()` function to run effects when watched values change.
-
 ## Release (2024-04-22)
 
 signal-utils 0.15.0 (minor)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ npm add signal-utils signal-polyfill
   - [@deepSignal](#deepSignal)
 - subtle utilities
   - [effect](#leaky-effect-via-queuemicrotask)
+  - [reaction](#reaction)
 
 ### `@signal`
 
@@ -483,6 +484,27 @@ effect(() => console.log(count.get());
 
 count.set(1);
 // => 1 logs
+```
+
+#### Reactions
+
+A reaction tracks a computation and calls an effect function when the value of
+the computation changes.
+
+```js
+import { Signal } from 'signal-polyfill';
+import { reaction } from 'signal-utils/subtle/reaction.js';
+
+const a = new Signal.State(0);
+const b = new Signal.State(1);
+
+reaction(
+  () => a.get() + b.get(), 
+  (value, previousValue) => console.log(value, previousValue)
+);
+
+a.set(1);
+// after a microtask, logs: 2, 1
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "vite-plugin-dts": "^3.8.1",
     "vitest": "^1.4.0"
   },
-  "packageManager": "pnpm@9.0.5",
+  "packageManager": "pnpm@9.0.6",
   "volta": {
     "node": "20.12.2",
     "pnpm": "9.0.5"

--- a/src/subtle/reaction.ts
+++ b/src/subtle/reaction.ts
@@ -1,0 +1,55 @@
+import { Signal } from "signal-polyfill";
+
+/**
+ * Reactions are a way to observe a value and run an effect when it changes.
+ *
+ * The `data` function is run and tracked in a computed signal. It returns a
+ * value that is compared to the previous value. If the value changes, the
+ * `effect` function is called with the new value and the previous value.
+ *
+ * @param data A function that returns the value to observe.
+ * @param effect A function that is called when the value changes.
+ * @param equals A function that compares two values for equality.
+ * @returns A function that stops the reaction.
+ */
+export const reaction = <T>(
+  data: () => T,
+  effect: (value: T, previousValue: T) => void,
+  equals = Object.is
+) => {
+  // Passing equals here doesn't seem to dedupe the effect calls.
+  const computed: Signal.Computed<T> | undefined = new Signal.Computed(data, {
+    equals,
+  });
+  let previousValue = computed.get();
+  let notify: (() => Promise<void>) | undefined = async () => {
+    await 0;
+    // Check if this reaction was unsubscribed
+    if (notify === undefined) {
+      return;
+    }
+    const value = computed.get();
+    if (!equals(value, previousValue)) {
+      try {
+        effect(value, previousValue);
+      } catch (e) {
+        // TODO: we actually want this to be unhandled, but Vitest complains.
+        // We probably don't want to enable dangerouslyIgnoreUnhandledErrors
+        // for all tests
+        console.error(e);
+      } finally {
+        previousValue = value;
+      }
+    }
+    watcher.watch();
+  };
+  const watcher = new Signal.subtle.Watcher(() => notify?.());
+  watcher.watch(computed);
+  return () => {
+    watcher.unwatch();
+    // TODO: Do we need this? Add a memory leak test.
+    // By severing the reference to the notify function, we allow the garbage
+    // collector to clean up the resources used by the watcher.
+    notify = undefined;
+  };
+};

--- a/src/subtle/reaction.ts
+++ b/src/subtle/reaction.ts
@@ -15,7 +15,7 @@ import { Signal } from "signal-polyfill";
 export const reaction = <T>(
   data: () => T,
   effect: (value: T, previousValue: T) => void,
-  equals = Object.is
+  equals = Object.is,
 ) => {
   // Passing equals here doesn't seem to dedupe the effect calls.
   const computed: Signal.Computed<T> | undefined = new Signal.Computed(data, {
@@ -23,6 +23,7 @@ export const reaction = <T>(
   });
   let previousValue = computed.get();
   let notify: (() => Promise<void>) | undefined = async () => {
+    // await 0 is a cheap way to queue a microtask
     await 0;
     // Check if this reaction was unsubscribed
     if (notify === undefined) {

--- a/src/subtle/reaction.ts
+++ b/src/subtle/reaction.ts
@@ -1,5 +1,19 @@
 import { Signal } from "signal-polyfill";
 
+export const __internal_testing__ = {
+  active: false,
+  lastError: null,
+} as { active: boolean; lastError: null | unknown };
+
+class ReactionError {
+  original: unknown;
+  name = "ReactionError";
+
+  constructor(original: unknown) {
+    this.original = original;
+  }
+}
+
 /**
  * Reactions are a way to observe a value and run an effect when it changes.
  *
@@ -37,7 +51,12 @@ export const reaction = <T>(
         // TODO: we actually want this to be unhandled, but Vitest complains.
         // We probably don't want to enable dangerouslyIgnoreUnhandledErrors
         // for all tests
-        console.error(e);
+        if (__internal_testing__) {
+          console.error(e);
+          __internal_testing__.lastError = e;
+        } else {
+          throw new ReactionError(e);
+        }
       } finally {
         previousValue = value;
       }

--- a/tests/subtle/reaction.test.ts
+++ b/tests/subtle/reaction.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, assert } from "vitest";
+import { describe, test, assert, afterEach } from "vitest";
 import { Signal } from "signal-polyfill";
-import { reaction } from "../../src/subtle/reaction.ts";
+import { reaction, __internal_testing__ } from "../../src/subtle/reaction.ts";
+
+afterEach(() => {
+  __internal_testing__.active = false;
+});
 
 describe("reaction()", () => {
   test("calls the effect function when the data function return value changes", async () => {
@@ -137,10 +141,15 @@ describe("reaction()", () => {
       },
     );
 
+    __internal_testing__.active = true;
     x.set(1);
     await 0;
     assert.strictEqual(callCount, 1);
     assert.strictEqual(thrown, true);
+    assert.strictEqual(
+      (__internal_testing__.lastError as Error).message,
+      "Oops",
+    );
 
     x.set(2);
     await 0;

--- a/tests/subtle/reaction.test.ts
+++ b/tests/subtle/reaction.test.ts
@@ -3,28 +3,30 @@ import { Signal } from "signal-polyfill";
 import { reaction } from "../../src/subtle/reaction.ts";
 
 describe("reaction()", () => {
-
   test("calls the effect function when the data function return value changes", async () => {
     const count = new Signal.State(0);
 
     let callCount = 0;
     let value, previousValue;
 
-    reaction(() => count.get(), (_value, _previousValue) => {
-      callCount++;
-      value = _value;
-      previousValue = _previousValue;
-    });
+    reaction(
+      () => count.get(),
+      (_value, _previousValue) => {
+        callCount++;
+        value = _value;
+        previousValue = _previousValue;
+      },
+    );
 
     // Effect callbacks are not called immediately
     assert.strictEqual(callCount, 0);
 
     await 0;
-    
+
     // Effect callbacks are not called until the data function changes
     assert.strictEqual(callCount, 0);
 
-    // Effect callbacks are called when the data function changes    
+    // Effect callbacks are called when the data function changes
     count.set(count.get() + 1);
     await 0;
     assert.strictEqual(callCount, 1);
@@ -45,15 +47,18 @@ describe("reaction()", () => {
     const count = new Signal.State(0);
 
     let callCount = 0;
-    const unsubscribe = reaction(() => count.get(), () => {
-      callCount++;
-    });
+    const unsubscribe = reaction(
+      () => count.get(),
+      () => {
+        callCount++;
+      },
+    );
 
     // Check reaction is live
     count.set(count.get() + 1);
     await 0;
     assert.strictEqual(callCount, 1);
-    
+
     unsubscribe();
 
     // Check reaction is not live
@@ -66,15 +71,18 @@ describe("reaction()", () => {
     const count = new Signal.State(0);
 
     let callCount = 0;
-    const unsubscribe = reaction(() => count.get(), () => {
-      callCount++;
-    });
+    const unsubscribe = reaction(
+      () => count.get(),
+      () => {
+        callCount++;
+      },
+    );
 
     // Check reaction is live
     count.set(count.get() + 1);
     await 0;
     assert.strictEqual(callCount, 1);
-    
+
     // Check reaction is not live
     count.set(count.get() + 1);
     unsubscribe();
@@ -87,13 +95,13 @@ describe("reaction()", () => {
     const b = new Signal.State(0);
 
     let callCount = 0;
-    let value, previousValue;
 
-    reaction(() => a.get() + b.get(), (_value, _previousValue) => {
-      callCount++;
-      value = _value;
-      previousValue = _previousValue;
-    });
+    reaction(
+      () => a.get() + b.get(),
+      (_value, _previousValue) => {
+        callCount++;
+      },
+    );
 
     // 1 + -1 still equals 0
     a.set(1);
@@ -109,22 +117,25 @@ describe("reaction()", () => {
     let value, previousValue;
     let thrown = false;
 
-    if (typeof process !== 'undefined') {
-      process.on('uncaughtException', (error) => {
-        console.log('uncaughtException', error);
+    if (typeof process !== "undefined") {
+      process.on("uncaughtException", (error) => {
+        console.log("uncaughtException", error);
       });
     }
 
-    reaction(() => x.get(), (_value, _previousValue) => {
-      callCount++;
-      value = _value;
-      previousValue = _previousValue;
-      if (value === 1) {
-        thrown = true;
-        throw new Error("Oops");
-      }
-      thrown = false;
-    });
+    reaction(
+      () => x.get(),
+      (_value, _previousValue) => {
+        callCount++;
+        value = _value;
+        previousValue = _previousValue;
+        if (value === 1) {
+          thrown = true;
+          throw new Error("Oops");
+        }
+        thrown = false;
+      },
+    );
 
     x.set(1);
     await 0;
@@ -138,5 +149,4 @@ describe("reaction()", () => {
     assert.strictEqual(value, 2);
     assert.strictEqual(previousValue, 1);
   });
-
 });

--- a/tests/subtle/reaction.test.ts
+++ b/tests/subtle/reaction.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, assert } from "vitest";
+import { Signal } from "signal-polyfill";
+import { reaction } from "../../src/subtle/reaction.ts";
+
+describe("reaction()", () => {
+
+  test("calls the effect function when the data function return value changes", async () => {
+    const count = new Signal.State(0);
+
+    let callCount = 0;
+    let value, previousValue;
+
+    reaction(() => count.get(), (_value, _previousValue) => {
+      callCount++;
+      value = _value;
+      previousValue = _previousValue;
+    });
+
+    // Effect callbacks are not called immediately
+    assert.strictEqual(callCount, 0);
+
+    await 0;
+    
+    // Effect callbacks are not called until the data function changes
+    assert.strictEqual(callCount, 0);
+
+    // Effect callbacks are called when the data function changes    
+    count.set(count.get() + 1);
+    await 0;
+    assert.strictEqual(callCount, 1);
+    assert.strictEqual(value, 1);
+    assert.strictEqual(previousValue, 0);
+
+    // is good enough to not freeze / OOM
+    for (let i = 0; i < 25; i++) {
+      count.set(count.get() + 1);
+      await 0;
+      assert.strictEqual(callCount, 2 + i);
+      assert.strictEqual(value, i + 2);
+      assert.strictEqual(previousValue, i + 1);
+    }
+  });
+
+  test("Unsubscribed reactions aren't called", async () => {
+    const count = new Signal.State(0);
+
+    let callCount = 0;
+    const unsubscribe = reaction(() => count.get(), () => {
+      callCount++;
+    });
+
+    // Check reaction is live
+    count.set(count.get() + 1);
+    await 0;
+    assert.strictEqual(callCount, 1);
+    
+    unsubscribe();
+
+    // Check reaction is not live
+    count.set(count.get() + 1);
+    await 0;
+    assert.strictEqual(callCount, 1);
+  });
+
+  test("You can unsubscribe while an effect is pending", async () => {
+    const count = new Signal.State(0);
+
+    let callCount = 0;
+    const unsubscribe = reaction(() => count.get(), () => {
+      callCount++;
+    });
+
+    // Check reaction is live
+    count.set(count.get() + 1);
+    await 0;
+    assert.strictEqual(callCount, 1);
+    
+    // Check reaction is not live
+    count.set(count.get() + 1);
+    unsubscribe();
+    await 0;
+    assert.strictEqual(callCount, 1);
+  });
+
+  test("equal data values don't trigger effect", async () => {
+    const a = new Signal.State(0);
+    const b = new Signal.State(0);
+
+    let callCount = 0;
+    let value, previousValue;
+
+    reaction(() => a.get() + b.get(), (_value, _previousValue) => {
+      callCount++;
+      value = _value;
+      previousValue = _previousValue;
+    });
+
+    // 1 + -1 still equals 0
+    a.set(1);
+    b.set(-1);
+    await 0;
+    assert.strictEqual(callCount, 0);
+  });
+
+  test("throwing in effect doesn't hang reaction", async () => {
+    const x = new Signal.State(0);
+
+    let callCount = 0;
+    let value, previousValue;
+    let thrown = false;
+
+    if (typeof process !== 'undefined') {
+      process.on('uncaughtException', (error) => {
+        console.log('uncaughtException', error);
+      });
+    }
+
+    reaction(() => x.get(), (_value, _previousValue) => {
+      callCount++;
+      value = _value;
+      previousValue = _previousValue;
+      if (value === 1) {
+        thrown = true;
+        throw new Error("Oops");
+      }
+      thrown = false;
+    });
+
+    x.set(1);
+    await 0;
+    assert.strictEqual(callCount, 1);
+    assert.strictEqual(thrown, true);
+
+    x.set(2);
+    await 0;
+    assert.strictEqual(callCount, 2);
+    assert.strictEqual(thrown, false);
+    assert.strictEqual(value, 2);
+    assert.strictEqual(previousValue, 1);
+  });
+
+});


### PR DESCRIPTION
This adds a `reaction()` utility that's similar to [MobX's reaction()](https://mobx.js.org/reactions.html#reaction) as mentioned in https://github.com/proposal-signals/signal-utils/issues/15#issuecomment-2062018823.

`reaction()` takes two arguments, a data function and an effect function. The data function is wrapped in a Computed, and when the return value of the data function changes, the effect function is called with the current and previous values. An optional equality function is accepted.

```ts
const x = new Signal.State(0);
reaction(() => x.get(), (value, previousValue) => {
  console.log('x changed', value, previousValue);
});
x.set(1);
await 0;
// x changed 0 1
```

The effect function is only called the first time the data function return value changes. It is not called with the initial value.

Reactions can be unsubscribed to by invoking the cleanup function that it returns.