### PR TITLE
Return dispose function from batchedEffect()

### DIFF
--- a/src/subtle/batched-effect.ts
+++ b/src/subtle/batched-effect.ts
@@ -20,6 +20,8 @@ let batchDepth = 0;
  * will return their updates value. Other computations, watcher, and effects
  * created outside of a batch that depend on updated signals will be run as
  * usual.
+ *
+ * @param fn The function to run inside the batch.
  */
 export const batch = (fn: () => void) => {
   batchDepth++;
@@ -68,6 +70,9 @@ export const batch = (fn: () => void) => {
  *
  * The effect also runs asynchronously, on the microtask queue, if any of the
  * signals it depends on have been updated outside of a `batch()` call.
+ *
+ * @param effectFn The function to run as an effect.
+ * @returns A function that stops and disposes the effect.
  */
 export const batchedEffect = (effectFn: () => void) => {
   const computed = new Signal.Computed(effectFn);
@@ -87,4 +92,8 @@ export const batchedEffect = (effectFn: () => void) => {
   const entry = { computed, watcher };
   watcher.watch(computed);
   computed.get();
+  return () => {
+    watcher.unwatch(computed);
+    notifiedEffects.delete(entry);
+  };
 };

--- a/src/subtle/reaction.ts
+++ b/src/subtle/reaction.ts
@@ -32,7 +32,7 @@ export const reaction = <T>(
   equals = Object.is,
 ) => {
   // Passing equals here doesn't seem to dedupe the effect calls.
-  const computed: Signal.Computed<T> | undefined = new Signal.Computed(data, {
+  const computed: Signal.Computed<T> = new Signal.Computed(data, {
     equals,
   });
   let previousValue = computed.get();
@@ -65,8 +65,9 @@ export const reaction = <T>(
   };
   const watcher = new Signal.subtle.Watcher(() => notify?.());
   watcher.watch(computed);
+
   return () => {
-    watcher.unwatch();
+    watcher.unwatch(computed);
     // TODO: Do we need this? Add a memory leak test.
     // By severing the reference to the notify function, we allow the garbage
     // collector to clean up the resources used by the watcher.


### PR DESCRIPTION
Addresses this comment: https://github.com/proposal-signals/signal-utils/pull/69#discussion_r1608511637

Also includes a fix to `reaction()`'s dispose function.