### PR TITLE
Remove setters from signalFunction()'s State

### DIFF
--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -183,7 +183,7 @@ export class State<Value> {
    * `error` or `resolvedValue` will remain as they were previously
    * until this promise resolves, and then they'll be updated to the new values.
    */
-  async retry() {
+  retry = async () => {
     try {
       /**
        * This function has two places where it can error:

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -194,7 +194,7 @@ export class State<Value> {
     } catch (e) {
       this.#caughtError.set(e);
     }
-  }
+  };
 
   async #dangerousRetry() {
     // We've previously had data, but we're about to run-again.

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -24,7 +24,6 @@ export function signalFunction<Return>(fn: () => Return): State<Return> {
  * State container that represents the asynchrony of a `signalFunction`
  */
 export class State<Value> {
-  
   #data = new Signal.State<SignalAsyncData<Value> | null>(null);
   get data() {
     this.#computed.get();
@@ -195,7 +194,7 @@ export class State<Value> {
     } catch (e) {
       this.#caughtError.set(e);
     }
-  };
+  }
 
   async #dangerousRetry() {
     // We've previously had data, but we're about to run-again.
@@ -223,5 +222,5 @@ export class State<Value> {
     this.#data.set(new SignalAsyncData<Value>(this.promise!));
 
     return this.promise;
-  };
+  }
 }

--- a/src/async-function.ts
+++ b/src/async-function.ts
@@ -24,22 +24,17 @@ export function signalFunction<Return>(fn: () => Return): State<Return> {
  * State container that represents the asynchrony of a `signalFunction`
  */
 export class State<Value> {
+  
   #data = new Signal.State<SignalAsyncData<Value> | null>(null);
-  #promise = new Signal.State<Value | undefined>(undefined);
-
   get data() {
     this.#computed.get();
     return this.#data.get();
   }
-  set data(value) {
-    this.#data.set(value);
-  }
+
+  #promise = new Signal.State<Value | undefined>(undefined);
   get promise() {
     this.#computed.get();
     return this.#promise.get();
-  }
-  set promise(value) {
-    this.#promise.set(value);
   }
 
   /**
@@ -53,9 +48,6 @@ export class State<Value> {
   get caughtError() {
     this.#computed.get();
     return this.#caughtError.get();
-  }
-  set caughtError(value) {
-    this.#caughtError.set(value);
   }
 
   #fn: () => Value;
@@ -192,29 +184,30 @@ export class State<Value> {
    * `error` or `resolvedValue` will remain as they were previously
    * until this promise resolves, and then they'll be updated to the new values.
    */
-  retry = async () => {
+  async retry() {
     try {
       /**
        * This function has two places where it can error:
        * - immediately when inovking `fn` (where auto-tracking occurs)
        * - after an await, "eventually"
        */
-      await this._dangerousRetry();
+      await this.#dangerousRetry();
     } catch (e) {
-      this.caughtError = e;
+      this.#caughtError.set(e);
     }
   };
 
-  _dangerousRetry = async () => {
+  async #dangerousRetry() {
     // We've previously had data, but we're about to run-again.
     // we need to do this again so `isLoading` goes back to `true` when re-running.
     // NOTE: we want to do this _even_ if this.data is already null.
-    //       it's all in the same tracking frame and the important thing is taht
+    //       it's all in the same tracking frame and the important thing is that
     //       we can't *read* data here.
-    this.data = null;
+    this.#data.set(null);
 
-    // We need to invoke this before going async so that tracked properties are consumed (entangled with) synchronously
-    this.promise = this.#fn();
+    // We need to invoke this before going async so that tracked properties are
+    // consumed (entangled with) synchronously
+    this.#promise.set(this.#fn());
 
     // TrackedAsyncData interacts with tracked data during instantiation.
     // We don't want this internal state to entangle with `signalFunction`
@@ -226,8 +219,8 @@ export class State<Value> {
      * This is detached from the tracking frame (via the above await),
      * se the UI can update accordingly, without causing us to refetch
      */
-    this.caughtError = null;
-    this.data = new SignalAsyncData(this.promise);
+    this.#caughtError.set(null);
+    this.#data.set(new SignalAsyncData<Value>(this.promise!));
 
     return this.promise;
   };


### PR DESCRIPTION
It seems like consumers of `signalFunction()`'s State return type should not be able to set the data, promise, and caughtError properties, so this PR removes the setters and uses the private signals for internal setting.

A couple of other small things:
- Converted `retry()` to a plain method, as I didn't see any case where it was torn off and needed to be bound
- Made dangerousRetry private
