### PR TITLE
Proposal: Add AsyncComputed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: wyvox/action-setup-pnpm@v3
+        with: { node-version: 22 }
       - run: pnpm install
       - run: pnpm build
       - run: pnpm vitest ${{ matrix.testenv.args }}

--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ An `AsyncComputed` instance tracks its "status", which is either `"initial"`,
 
 - `constructor<T>(fn, options)`
   - arguments:
-    - `fn: (signal: AbortSignal) => Promise<T>`: The compute function.
+    - `fn: (abortSignal: AbortSignal) => Promise<T>`: The compute function.
       Synchronous signal access (before the first await) is tracked.
       
       If a run is preempted by another run because dependencies change, the

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "packageManager": "pnpm@9.0.6",
   "volta": {
-    "node": "20.12.2",
+    "node": "22.0.0",
     "pnpm": "9.0.5"
   }
 }

--- a/src/async-computed.ts
+++ b/src/async-computed.ts
@@ -147,7 +147,7 @@ export class AsyncComputed<T> {
    */
   constructor(
     fn: (abortSignal: AbortSignal) => Promise<T>,
-    options?: AsyncComputedOptions<T>
+    options?: AsyncComputedOptions<T>,
   ) {
     this.#value = new Signal.State(options?.initialValue);
     this.#computed = new Signal.Computed(() => {
@@ -189,7 +189,7 @@ export class AsyncComputed<T> {
           this.#error.set(error);
           this.#value.set(undefined);
           this.#deferred.get()!.reject(error);
-        }
+        },
       );
     });
     this.#watcher = new Signal.subtle.Watcher(async () => {

--- a/src/async-computed.ts
+++ b/src/async-computed.ts
@@ -1,0 +1,202 @@
+import { Signal } from "signal-polyfill";
+
+export type AsyncComputedState = "initial" | "pending" | "complete" | "error";
+
+export interface AsyncComputedOptions<T> {
+  /**
+   * The initial value of the AsyncComputed.
+   */
+  initialValue?: T;
+}
+
+/**
+ * A signal-like object that represents an asynchronous computation.
+ *
+ * AsyncComputed takes a compute function that performs an asynchronous
+ * computation and runs it inside a computed signal, while tracking the state of
+ * the computation, including its most recent completion value and error.
+ *
+ * Compute functions are run when the `state`, `value`, `error`, or `complete`
+ * properties are read, and are re-run when any signals that they read change.
+ *
+ * If a new run of the compute function is started before the previous run has
+ * completed, the previous run will have its AbortSignal aborted, and the
+ * result of the previous run will be ignored.
+ */
+export class AsyncComputed<T> {
+  // Whether we have been notified of a pending update from the watcher. This is
+  // set synchronously when any dependencies of the compute function change.
+  #isNotified = false;
+  #state = new Signal.State<AsyncComputedState>("initial");
+
+  /**
+   * The current state of the AsyncComputed, which is one of 'initial',
+   * 'pending', 'complete', or 'error'.
+   *
+   * The state will be 'initial' until the compute function is first run.
+   *
+   * The state will be 'pending' while the compute function is running. If the
+   * state is 'pending', the `value` and `error` properties will be the result
+   * of the previous run of the compute function.
+   *
+   * The state will be 'complete' when the compute function has completed
+   * successfully. If the state is 'complete', the `value` property will be the
+   * result of the previous run of the compute function and the `error` property
+   * will be `undefined`.
+   *
+   * The state will be 'error' when the compute function has completed with an
+   * error. If the state is 'error', the `error` property will be the error that
+   * was thrown by the previous run of the compute function and the `value`
+   * property will be `undefined`.
+   *
+   * This value is read from a signal, so any signals that read the state will
+   * be marked as dependents of it.
+   */
+  get state() {
+    // Unconditionally read the state signal to ensure that any signals that
+    // read the state are marked as dependents.
+    const currentState = this.#state.get();
+    return this.#isNotified ? "pending" : currentState;
+  }
+
+  /**
+   * The last value that the compute function resolved with, or `undefined` if
+   * the last run of the compute function threw an error, or if the compute
+   * function has not yet been run.
+   *
+   * This value is read from a signal, so any signals that read the state will
+   * be marked as dependents of it.
+   */
+  #value: Signal.State<T | undefined>;
+  get value() {
+    this.run();
+    return this.#value.get();
+  }
+
+  /**
+   * The last error that the compute function threw, or `undefined` if the last
+   * run of the compute function resolved successfully, or if the compute
+   * function has not yet been run.
+   *
+   * This value is read from a signal, so any signals that read the state will
+   * be marked as dependents of it.
+   */
+  #error = new Signal.State<unknown | undefined>(undefined);
+  get error() {
+    this.run();
+    return this.#error.get();
+  }
+
+  #deferred = new Signal.State<PromiseWithResolvers<T> | undefined>(undefined);
+
+  /**
+   * A promise that resolves when the compute functino has completed, or rejects
+   * if the compute functino throws an error.
+   *
+   * If a new run of the compute functino is started before the previous run has
+   * completed, the promise will resolve with the result of the new run.
+   */
+  get complete(): Promise<T> {
+    this.run();
+    // run() will have created a new deferred if needed.
+    return this.#deferred.get()!.promise;
+  }
+
+  #computed: Signal.Computed<void>;
+
+  #watcher: Signal.subtle.Watcher;
+
+  // A unique ID for the current run. This is used to ensure that runs that have
+  // been preempted by a new run do not update state or resolve the deferred
+  // with the wrong result.
+  #currentRunId = 0;
+
+  #currentAbortController?: AbortController;
+
+  /**
+   * Creates a new AsyncComputed signal.
+   *
+   * @param fn The function that performs the asynchronous computation. Any
+   * signals read synchronously - that is, before the first await - will be
+   * marked as dependencies of the AsyncComputed, and cause the function to
+   * re-run when they change.
+   */
+  constructor(
+    fn: (signal: AbortSignal) => Promise<T>,
+    options?: AsyncComputedOptions<T>
+  ) {
+    this.#value = new Signal.State(options?.initialValue);
+    this.#computed = new Signal.Computed(() => {
+      const runId = ++this.#currentRunId;
+      // Untrack reading the state signal to avoid triggering the computed when
+      // the state changes.
+      const state = Signal.subtle.untrack(() => this.#state.get());
+
+      // If we're not already pending, create a new deferred to track the
+      // completion of the run.
+      if (state !== "pending") {
+        this.#deferred.set(Promise.withResolvers());
+      }
+      this.#isNotified = false;
+      this.#state.set("pending");
+
+      this.#currentAbortController?.abort();
+      this.#currentAbortController = new AbortController();
+
+      fn(this.#currentAbortController.signal).then(
+        (result) => {
+          // If we've been preempted by a new run, don't update the state or
+          // resolve the deferred.
+          if (runId !== this.#currentRunId) {
+            return;
+          }
+          this.#state.set("complete");
+          this.#value.set(result);
+          this.#error.set(undefined);
+          this.#deferred.get()!.resolve(result);
+        },
+        (error) => {
+          // If we've been preempted by a new run, don't update the state or
+          // resolve the deferred.
+          if (runId !== this.#currentRunId) {
+            return;
+          }
+          this.#state.set("error");
+          this.#error.set(error);
+          this.#value.set(undefined);
+          this.#deferred.get()!.reject(error);
+        }
+      );
+    });
+    this.#watcher = new Signal.subtle.Watcher(() => {
+      this.#isNotified = true;
+    });
+    this.#watcher.watch(this.#computed);
+  }
+
+  /**
+   * Returns the last value that the compute function resolved with, or
+   * `undefined` if the compute function has not yet been run.
+   *
+   * @throws The last error that the compute function threw, is the last run of
+   * the compute function threw an error.
+   */
+  get() {
+    const state = this.state;
+    if (
+      state === "error" ||
+      (state === "pending" && this.error !== undefined)
+    ) {
+      throw this.error;
+    }
+    return this.value;
+  }
+
+  /**
+   * Runs the compute function if it is not already running and its dependencies
+   * have changed.
+   */
+  run() {
+    this.#computed.get();
+  }
+}

--- a/src/async-computed.ts
+++ b/src/async-computed.ts
@@ -146,7 +146,7 @@ export class AsyncComputed<T> {
    * @param options.initialValue The initial value of the AsyncComputed.
    */
   constructor(
-    fn: (signal: AbortSignal) => Promise<T>,
+    fn: (abortSignal: AbortSignal) => Promise<T>,
     options?: AsyncComputedOptions<T>
   ) {
     this.#value = new Signal.State(options?.initialValue);

--- a/src/async-computed.ts
+++ b/src/async-computed.ts
@@ -90,10 +90,10 @@ export class AsyncComputed<T> {
   #deferred = new Signal.State<PromiseWithResolvers<T> | undefined>(undefined);
 
   /**
-   * A promise that resolves when the compute functino has completed, or rejects
-   * if the compute functino throws an error.
+   * A promise that resolves when the compute function has completed, or rejects
+   * if the compute function throws an error.
    *
-   * If a new run of the compute functino is started before the previous run has
+   * If a new run of the compute function is started before the previous run has
    * completed, the promise will resolve with the result of the new run.
    */
   get complete(): Promise<T> {
@@ -172,6 +172,7 @@ export class AsyncComputed<T> {
     });
     this.#watcher = new Signal.subtle.Watcher(() => {
       this.#isNotified = true;
+      this.#watcher.watch();
     });
     this.#watcher.watch(this.#computed);
   }

--- a/src/async-computed.ts
+++ b/src/async-computed.ts
@@ -120,10 +120,12 @@ export class AsyncComputed<T> {
    * signals read synchronously - that is, before the first await - will be
    * marked as dependencies of the AsyncComputed, and cause the function to
    * re-run when they change.
+   *
+   * @param options.initialValue The initial value of the AsyncComputed.
    */
   constructor(
     fn: (signal: AbortSignal) => Promise<T>,
-    options?: AsyncComputedOptions<T>
+    options?: AsyncComputedOptions<T>,
   ) {
     this.#value = new Signal.State(options?.initialValue);
     this.#computed = new Signal.Computed(() => {
@@ -165,7 +167,7 @@ export class AsyncComputed<T> {
           this.#error.set(error);
           this.#value.set(undefined);
           this.#deferred.get()!.reject(error);
-        }
+        },
       );
     });
     this.#watcher = new Signal.subtle.Watcher(() => {

--- a/tests/async-computed.test.ts
+++ b/tests/async-computed.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, assert } from "vitest";
+import { Signal } from "signal-polyfill";
+import { AsyncComputed } from "../src/async-computed.ts";
+
+describe("AsyncComputed", () => {
+  test("initialValue", async () => {
+    const task = new AsyncComputed(async () => 1, { initialValue: 0 });
+    assert.strictEqual(task.value, 0);
+  });
+
+  test("AsyncComputed runs", async () => {
+    const task = new AsyncComputed(async () => {
+      // Make the task take more than one microtask
+      await 0;
+      return 1;
+    });
+    assert.equal(task.state, "initial");
+
+    // Getting the value starts the task
+    assert.strictEqual(task.value, undefined);
+    assert.strictEqual(task.error, undefined);
+    assert.equal(task.state, "pending");
+
+    const result = await task.complete;
+
+    assert.equal(task.state, "complete");
+    assert.strictEqual(task.value, 1);
+    assert.strictEqual(result, 1);
+    assert.strictEqual(task.error, undefined);
+  });
+
+  test("AsyncComputed re-runs when signal dependencies change", async () => {
+    const dep = new Signal.State("a");
+    const task = new AsyncComputed(async () => {
+      // Read dependencies before first await
+      const value = dep.get();
+      return value;
+    });
+
+    await task.complete;
+    assert.equal(task.state, "complete");
+    assert.strictEqual(task.value, "a");
+    assert.strictEqual(task.error, undefined);
+
+    dep.set("b");
+    assert.equal(task.state, "pending");
+
+    await task.complete;
+    assert.equal(task.state, "complete");
+    assert.strictEqual(task.value, "b");
+    assert.strictEqual(task.error, undefined);
+  });
+
+  test("Preemptive runs reuse the same completed promise", async () => {
+    const dep = new Signal.State("a");
+    const deferredOne = Promise.withResolvers<void>();
+    let deferred = deferredOne;
+    const abortSignals: Array<AbortSignal> = [];
+    const task = new AsyncComputed(async (abortSignal) => {
+      // Read dependencies before first await
+      const value = dep.get();
+
+      abortSignals.push(abortSignal);
+      // Wait until we're told to go. The first run will wait so that the
+      // second run can preempt it.
+      await deferred.promise;
+      return value;
+    });
+
+    // Capture the promise that the task will complete
+    const firstRunComplete = task.complete;
+
+    // Trigger a new run with a new deferred
+    const deferredTwo = Promise.withResolvers<void>();
+    deferred = deferredTwo;
+    dep.set("b");
+    const secondRunComplete = task.complete;
+
+    assert.equal(task.state, "pending");
+    assert.strictEqual(abortSignals.length, 2);
+    assert.strictEqual(abortSignals[0]!.aborted, true);
+    assert.strictEqual(abortSignals[1]!.aborted, false);
+
+    // We should not have created a new Promise. The first Promise should be
+    // resolved with the result of the second run.
+    assert.strictEqual(firstRunComplete, secondRunComplete);
+
+    // Resolve the second run
+    deferredTwo.resolve();
+    const result = await task.complete;
+    assert.equal(result, "b");
+  });
+
+  test("AsyncComputed errors and can re-run", async () => {
+    const dep = new Signal.State("a");
+    const task = new AsyncComputed(async () => {
+      // Read dependencies before first await
+      const value = dep.get();
+      await 0;
+      if (value === "a") {
+        throw new Error("a");
+      }
+      return value;
+    });
+
+    task.run();
+    assert.equal(task.state, "pending");
+
+    try {
+      await task.complete;
+      assert.fail("Task should have thrown");
+    } catch (error) {
+      assert.equal(task.state, "error");
+      assert.strictEqual(task.value, undefined);
+      assert.strictEqual(task.error, error);
+    }
+
+    // Check that the task can re-run after an error
+
+    dep.set("b");
+    assert.equal(task.state, "pending");
+    await task.complete;
+    assert.strictEqual(task.value, "b");
+    assert.strictEqual(task.error, undefined);
+  });
+
+  test("get() throws on error", async () => {
+    const task = new AsyncComputed(async () => {
+      throw new Error("A");
+    });
+    task.run();
+    await task.complete.catch(() => {});
+    assert.throws(() => task.get());
+  });
+
+  test("can chain a computed signal", async () => {
+    const dep = new Signal.State("a");
+    const task = new AsyncComputed(async () => {
+      // Read dependencies before first await
+      const value = dep.get();
+      await 0;
+      if (value === "b") {
+        throw new Error("b");
+      }
+      return value;
+    });
+    const computed = new Signal.Computed(() => task.get());
+    assert.strictEqual(computed.get(), undefined);
+
+    await task.complete;
+    assert.strictEqual(computed.get(), "a");
+
+    dep.set("b");
+    await task.complete.catch(() => {});
+    assert.throws(() => computed.get());
+
+    dep.set("c");
+    await task.complete;
+    assert.strictEqual(computed.get(), "c");
+  });
+});

--- a/tests/async-computed.test.ts
+++ b/tests/async-computed.test.ts
@@ -14,16 +14,16 @@ describe("AsyncComputed", () => {
       await 0;
       return 1;
     });
-    assert.equal(task.state, "initial");
+    assert.equal(task.status, "initial");
 
     // Getting the value starts the task
     assert.strictEqual(task.value, undefined);
     assert.strictEqual(task.error, undefined);
-    assert.equal(task.state, "pending");
+    assert.equal(task.status, "pending");
 
     const result = await task.complete;
 
-    assert.equal(task.state, "complete");
+    assert.equal(task.status, "complete");
     assert.strictEqual(task.value, 1);
     assert.strictEqual(result, 1);
     assert.strictEqual(task.error, undefined);
@@ -38,20 +38,20 @@ describe("AsyncComputed", () => {
     });
 
     await task.complete;
-    assert.equal(task.state, "complete");
+    assert.equal(task.status, "complete");
     assert.strictEqual(task.value, "a");
     assert.strictEqual(task.error, undefined);
 
     dep.set("b");
-    assert.equal(task.state, "pending");
+    assert.equal(task.status, "pending");
 
     await task.complete;
-    assert.equal(task.state, "complete");
+    assert.equal(task.status, "complete");
     assert.strictEqual(task.value, "b");
     assert.strictEqual(task.error, undefined);
 
     dep.set("c");
-    assert.equal(task.state, "pending");
+    assert.equal(task.status, "pending");
   });
 
   test("Preemptive runs reuse the same completed promise", async () => {
@@ -79,10 +79,10 @@ describe("AsyncComputed", () => {
     dep.set("b");
     const secondRunComplete = task.complete;
 
-    assert.equal(task.state, "pending");
+    assert.equal(task.status, "pending");
     assert.strictEqual(abortSignals.length, 2);
-    assert.strictEqual(abortSignals[0]!.aborted, true);
-    assert.strictEqual(abortSignals[1]!.aborted, false);
+    assert.strictEqual(abortSignals[0].aborted, true);
+    assert.strictEqual(abortSignals[1].aborted, false);
 
     // We should not have created a new Promise. The first Promise should be
     // resolved with the result of the second run.
@@ -107,13 +107,13 @@ describe("AsyncComputed", () => {
     });
 
     task.run();
-    assert.equal(task.state, "pending");
+    assert.equal(task.status, "pending");
 
     try {
       await task.complete;
       assert.fail("Task should have thrown");
     } catch (error) {
-      assert.equal(task.state, "error");
+      assert.equal(task.status, "error");
       assert.strictEqual(task.value, undefined);
       assert.strictEqual(task.error, error);
     }
@@ -121,7 +121,7 @@ describe("AsyncComputed", () => {
     // Check that the task can re-run after an error
 
     dep.set("b");
-    assert.equal(task.state, "pending");
+    assert.equal(task.status, "pending");
     await task.complete;
     assert.strictEqual(task.value, "b");
     assert.strictEqual(task.error, undefined);
@@ -178,22 +178,22 @@ describe("AsyncComputed", () => {
     });
 
     assert.strictEqual(task2.get(), undefined);
-    assert.strictEqual(task2.state, "pending");
+    assert.strictEqual(task2.status, "pending");
 
     await task2.complete;
     assert.strictEqual(task2.get(), "a");
-    assert.strictEqual(task2.state, "complete");
+    assert.strictEqual(task2.status, "complete");
 
     dep.set("b");
-    assert.strictEqual(task2.state, "pending");
+    assert.strictEqual(task2.status, "pending");
     await task2.complete.catch(() => {});
     assert.throws(() => task2.get());
-    assert.strictEqual(task2.state, "error");
+    assert.strictEqual(task2.status, "error");
 
     dep.set("c");
-    assert.strictEqual(task2.state, "pending");
+    assert.strictEqual(task2.status, "pending");
     await task2.complete;
     assert.strictEqual(task2.get(), "c");
-    assert.strictEqual(task2.state, "complete");
+    assert.strictEqual(task2.status, "complete");
   });
 });

--- a/tests/async-computed.test.ts
+++ b/tests/async-computed.test.ts
@@ -81,8 +81,8 @@ describe("AsyncComputed", () => {
 
     assert.equal(task.status, "pending");
     assert.strictEqual(abortSignals.length, 2);
-    assert.strictEqual(abortSignals[0].aborted, true);
-    assert.strictEqual(abortSignals[1].aborted, false);
+    assert.strictEqual(abortSignals[0]!.aborted, true);
+    assert.strictEqual(abortSignals[1]!.aborted, false);
 
     // We should not have created a new Promise. The first Promise should be
     // resolved with the result of the second run.


### PR DESCRIPTION
Sorry for not opening an issue first, but I had this implementation of an AsyncComputed that I thought could be discussed either for inclusion or as a direction for `signalFunction()` or a future Relay implementation.

Conceptually AsyncComputed is very similar to `signalFunction()` or Relays, so there's a ton of overlap. I wrote this while trying to wrap my head around https://github.com/tc39/proposal-signals/issues/30 and the `signalFunction()`. It's partly based on the shape of the [Task](https://lit.dev/docs/data/task/) utility that we have in Lit.

As I wrote in https://github.com/tc39/proposal-signals/issues/30#issuecomment-2211568430, AsyncComputed has these features:
- It takes a Promise-returning computation function with an AbortSignal argument: `(signal: AbortSignal) => Promise<T>`
- The function is called within an internal Signal.Computed, so all synchronous signal access is tracked
- When the internal computed runs, it re-runs the compute function, pre-empting any pending run and aborting their abort signals.
- It has signal-backed getters for its state:
  - `state`: one of `'initial'`, `'pending'`, `'complete'`, or `'error'`. `state` will _synchronously_ change to `'pending'` when dependency signals are dirtied.
  - `value`: the last completion value if the last completion type was `'complete'`, otherwise undefined
  - `error`: the last error if the last completion type was `'error'`, otherwise undefined
- It has a `complete` getter that returns a Promise that settles when the AsyncComputed does. If a new run is triggered before the previous completes, the same Promise instance is kept. If a new run is started after a completion, a new Promise is created.
- It has a `get()` method that returns the latest completion value or throws if the last completion was an error.
- It has a `run()` method to manually read from the internal computed and trigger a run. Otherwise the computed is read from the various getters.

I found this API shape and implementation to be relatively simple, and I'm starting to use it throughout my code base.

Compared to `signalFunction()` I think this mainly has a slightly smaller public API, doesn't use `SignalAsyncData`, and has AbortSignal support. The completion promise behavior is different - AsyncComputed's `complete` promise will be shared among concurrent/preempted runs and only settled by the most recent run.

Compared to Relays I think the differences are that there are no consumer APIs for altering the state, and instead of passing `get` and `set` functions to the compute function, it relies on the return value of the compute function, and there's no update/destroy concept inside the compute function.

I think it's worth noting that utilities like this are also similar in some ways to libraries like TanStack Query, which are very feature-rich with things like caching, debouncing, etc. I think most of those feature can be implemented as part of the compute function. It may be helpful to pass the AsyncComputed instance back to the compute function to use as a key for caches or WeakMaps that store last invocation time for debouncing. Implementing debouncing inside the compute function would also require some kind of conditional gate on a run - either a `shouldRun` function in the options, or supporting an AbortError being thrown synchronously from the compute function as a way to cancel preemption.