### PR TITLE
Annotate deep function as a function, not a decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Inspiration for deep reactivity comes from:
 
 ### `deep` function
 
-A utility decorator for recursively, deeply, and lazily auto-tracking JSON-serializable structures at any depth or size.
+A utility function for recursively, deeply, and lazily auto-tracking JSON-serializable structures at any depth or size.
 
 ```gjs
 import { deep } from 'signal-utils/deep';


### PR DESCRIPTION
i'm not sure if i'm right but i think this is meant to say function not decorator?