### PR TITLE
Bugfix: Accessing AsyncComputed status property should trigger computed function

### DIFF
--- a/src/async-computed.ts
+++ b/src/async-computed.ts
@@ -57,6 +57,7 @@ export class AsyncComputed<T> {
    * already.
    */
   get status() {
+    this.run();
     // Unconditionally read the status signal to ensure that any signals that
     // read it are tracked as dependents.
     const currentState = this.#status.get();

--- a/tests/async-computed.test.ts
+++ b/tests/async-computed.test.ts
@@ -14,9 +14,9 @@ describe("AsyncComputed", () => {
       await 0;
       return 1;
     });
-    assert.equal(task.status, "initial");
 
-    // Getting the value starts the task
+    // Getting the value (or status and other properties) starts the task
+    assert.equal(task.status, "pending");
     assert.strictEqual(task.value, undefined);
     assert.strictEqual(task.error, undefined);
     assert.equal(task.status, "pending");


### PR DESCRIPTION
Same as value, error, and complete already do. Otherwise, only reading status isn't sufficient for a dependency to get tracked.