### PR TITLE
Emit TypeScript declaration maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "bundler",
     "declaration": true,
     "emitDeclarationOnly": true,
+    "declarationMap": true,
 
     /**
      Stylistic / linting. Does not provide extra type safety.


### PR DESCRIPTION
This allows a TypeScript compiler looking at an installed `signal-utils` to know where the original source files are published, which allows features like jump-to-definition in VSCode to take you the more useful `.ts` file instead of the generated `.d.ts` one.