### PR TITLE
Make SignalArray subclassable and constructor match Array

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -51,54 +51,12 @@ function convertToInt(prop: number | string | symbol): number | null {
   return num % 1 === 0 ? num : null;
 }
 
-// This rule is correct in the general case, but it doesn't understand
-// declaration merging, which is how we're using the interface here. This says
-// `SignalArray` acts just like `Array<T>`, but also has the properties
-// declared via the `class` declaration above -- but without the cost of a
-// subclass, which is much slower than the proxied array behavior. That is: a
-// `SignalArray` *is* an `Array`, just with a proxy in front of accessors and
-// setters, rather than a subclass of an `Array` which would be de-optimized by
-// the browsers.
-//
-export interface SignalArray<T = unknown> extends Array<T> {}
-
-export class SignalArray<T = unknown> {
-  /**
-   * Creates an array from an iterable object.
-   * @param iterable An iterable object to convert to an array.
-   */
-  static from<T>(iterable: Iterable<T> | ArrayLike<T>): SignalArray<T>;
-
-  /**
-   * Creates an array from an iterable object.
-   * @param iterable An iterable object to convert to an array.
-   * @param mapfn A mapping function to call on every element of the array.
-   * @param thisArg Value of 'this' used to invoke the mapfn.
-   */
-  static from<T, U>(
-    iterable: Iterable<T> | ArrayLike<T>,
-    mapfn: (v: T, k: number) => U,
-    thisArg?: unknown,
-  ): SignalArray<U>;
-
-  static from<T, U>(
-    iterable: Iterable<T> | ArrayLike<T>,
-    mapfn?: (v: T, k: number) => U,
-    thisArg?: unknown,
-  ): SignalArray<T> | SignalArray<U> {
-    return mapfn
-      ? new SignalArray(Array.from(iterable, mapfn, thisArg))
-      : new SignalArray(Array.from(iterable));
-  }
-
-  static of<T>(...arr: T[]): SignalArray<T> {
-    return new SignalArray(arr);
-  }
-
-  constructor(arr: T[] = []) {
-    let clone = arr.slice();
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let self = this;
+export class SignalArray<T = unknown> extends Array<T> {
+  constructor(arrayLength?: number);
+  constructor(arrayLength: number);
+  constructor(...items: T[]);
+  constructor(...args: T[]) {
+    super(...args);
 
     let boundFns = new Map<string | symbol, (...args: any[]) => any>();
 
@@ -109,13 +67,13 @@ export class SignalArray<T = unknown> {
      */
     let nativelyAccessingLengthFromPushOrUnshift = false;
 
-    return new Proxy(clone, {
+    return new Proxy(this, {
       get(target, prop /*, _receiver */) {
         let index = convertToInt(prop);
 
         if (index !== null) {
-          self.#readStorageFor(index);
-          self.#collection.get();
+          target.#readStorageFor(index);
+          target.#collection.get();
 
           return target[index];
         }
@@ -132,7 +90,7 @@ export class SignalArray<T = unknown> {
           if (nativelyAccessingLengthFromPushOrUnshift) {
             nativelyAccessingLengthFromPushOrUnshift = false;
           } else {
-            self.#collection.get();
+            target.#collection.get();
           }
 
           return target[prop];
@@ -150,7 +108,7 @@ export class SignalArray<T = unknown> {
 
           if (fn === undefined) {
             fn = (...args) => {
-              self.#collection.get();
+              target.#collection.get();
               return (target as any)[prop](...args);
             };
 
@@ -169,10 +127,10 @@ export class SignalArray<T = unknown> {
         let index = convertToInt(prop);
 
         if (index !== null) {
-          self.#dirtyStorageFor(index);
-          self.#collection.set(null);
+          target.#dirtyStorageFor(index);
+          target.#collection.set(null);
         } else if (prop === "length") {
-          self.#collection.set(null);
+          target.#collection.set(null);
         }
 
         return true;
@@ -208,9 +166,6 @@ export class SignalArray<T = unknown> {
   }
 }
 
-// Ensure instanceof works correctly
-Object.setPrototypeOf(SignalArray.prototype, Array.prototype);
-
-export function signalArray<Item>(x?: Item[]) {
-  return new SignalArray(x);
+export function signalArray<Item>(x: Item[] = []) {
+  return new SignalArray(...x);
 }

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -44,7 +44,7 @@ expectTypeOf<SignalArray<unknown>>().toMatchTypeOf<Array<unknown>>();
 
 describe("SignalArray", function () {
   test("Can get values on array directly", () => {
-    let arr = new SignalArray(["foo"]);
+    let arr = new SignalArray("foo");
 
     assert.equal(arr[0], "foo");
   });
@@ -96,21 +96,21 @@ describe("SignalArray", function () {
 
     test("concat", () => {
       let arr = new SignalArray();
-      let arr2 = arr.concat([1], new SignalArray([2]));
+      let arr2 = arr.concat([1], SignalArray.of(2));
 
       assert.deepEqual(arr2, [1, 2]);
-      assert.notOk(arr2 instanceof SignalArray);
+      assert.ok(arr2 instanceof SignalArray);
     });
 
     test("copyWithin", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       arr.copyWithin(1, 0, 1);
 
       assert.deepEqual(arr, [1, 1, 3]);
     });
 
     test("entries", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let iter = arr.entries();
 
       assert.deepEqual(iter.next().value, [0, 1]);
@@ -120,7 +120,7 @@ describe("SignalArray", function () {
     });
 
     test("every", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.ok(arr.every((v) => typeof v === "number"));
       assert.notOk(arr.every((v) => v !== 2));
@@ -144,15 +144,15 @@ describe("SignalArray", function () {
     });
 
     test("filter", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let arr2 = arr.filter((v) => v > 1);
 
       assert.deepEqual(arr2, [2, 3]);
-      assert.notOk(arr2 instanceof SignalArray);
+      assert.ok(arr2 instanceof SignalArray);
     });
 
     test("find", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.equal(
         arr.find((v) => v > 1),
@@ -161,7 +161,7 @@ describe("SignalArray", function () {
     });
 
     test("findIndex", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.equal(
         arr.findIndex((v) => v > 1),
@@ -170,14 +170,14 @@ describe("SignalArray", function () {
     });
 
     test("flat", () => {
-      let arr = new SignalArray([1, 2, [3]]);
+      let arr = new SignalArray<number | Array<number>>(1, 2, [3]);
 
       assert.deepEqual(arr.flat(), [1, 2, 3]);
       assert.deepEqual(arr, [1, 2, [3]]);
     });
 
     test("flatMap", () => {
-      let arr = new SignalArray([1, 2, [3]]);
+      let arr = new SignalArray<number | Array<number>>(1, 2, [3]);
 
       assert.deepEqual(
         arr.flatMap((v) => (typeof v === "number" ? v + 1 : v)),
@@ -187,33 +187,33 @@ describe("SignalArray", function () {
     });
 
     test("forEach", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       arr.forEach((v, i) => assert.equal(v, i + 1));
     });
 
     test("includes", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.equal(arr.includes(1), true);
       assert.equal(arr.includes(5), false);
     });
 
     test("indexOf", () => {
-      let arr = new SignalArray([1, 2, 1]);
+      let arr = new SignalArray(1, 2, 1);
 
       assert.equal(arr.indexOf(1), 0);
       assert.equal(arr.indexOf(5), -1);
     });
 
     test("join", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.equal(arr.join(","), "1,2,3");
     });
 
     test("keys", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let iter = arr.keys();
 
       assert.equal(iter.next().value, 0);
@@ -223,22 +223,22 @@ describe("SignalArray", function () {
     });
 
     test("lastIndexOf", () => {
-      let arr = new SignalArray([3, 2, 3]);
+      let arr = new SignalArray(3, 2, 3);
 
       assert.equal(arr.lastIndexOf(3), 2);
       assert.equal(arr.lastIndexOf(5), -1);
     });
 
     test("map", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let arr2 = arr.map((v) => v + 1);
 
       assert.deepEqual(arr2, [2, 3, 4]);
-      assert.notOk(arr2 instanceof SignalArray);
+      assert.ok(arr2 instanceof SignalArray);
     });
 
     test("pop", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let val = arr.pop();
 
       assert.deepEqual(arr, [1, 2]);
@@ -246,7 +246,7 @@ describe("SignalArray", function () {
     });
 
     test("push", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let val = arr.push(4);
 
       assert.deepEqual(arr, [1, 2, 3, 4]);
@@ -254,7 +254,7 @@ describe("SignalArray", function () {
     });
 
     test("reduce", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.equal(
         arr.reduce((s, v) => s + v, ""),
@@ -263,7 +263,7 @@ describe("SignalArray", function () {
     });
 
     test("reduceRight", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.equal(
         arr.reduceRight((s, v) => s + v, ""),
@@ -272,14 +272,14 @@ describe("SignalArray", function () {
     });
 
     test("reverse", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       arr.reverse();
 
       assert.deepEqual(arr, [3, 2, 1]);
     });
 
     test("shift", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let val = arr.shift();
 
       assert.deepEqual(arr, [2, 3]);
@@ -287,23 +287,23 @@ describe("SignalArray", function () {
     });
 
     test("slice", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let arr2 = arr.slice();
 
       assert.notEqual(arr, arr2);
-      assert.notOk(arr2 instanceof SignalArray);
+      assert.ok(arr2 instanceof SignalArray);
       assert.deepEqual(arr, arr2);
     });
 
     test("some", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
 
       assert.ok(arr.some((v) => v > 1));
       assert.notOk(arr.some((v) => v < 1));
     });
 
     test("sort", () => {
-      let arr = new SignalArray([3, 1, 2]);
+      let arr = new SignalArray(3, 1, 2);
       let arr2 = arr.sort();
 
       assert.equal(arr, arr2);
@@ -311,7 +311,7 @@ describe("SignalArray", function () {
     });
 
     test("sort (with method)", () => {
-      let arr = new SignalArray([3, 1, 2, 2]);
+      let arr = new SignalArray(3, 1, 2, 2);
       let arr2 = arr.sort((a, b) => {
         if (a > b) return -1;
         if (a < b) return 1;
@@ -323,16 +323,16 @@ describe("SignalArray", function () {
     });
 
     test("splice", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let arr2 = arr.splice(1, 1);
 
-      assert.notOk(arr2 instanceof SignalArray);
+      assert.ok(arr2 instanceof SignalArray);
       assert.deepEqual(arr, [1, 3]);
       assert.deepEqual(arr2, [2]);
     });
 
     test("unshift", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let val = arr.unshift(0);
 
       assert.deepEqual(arr, [0, 1, 2, 3]);
@@ -340,7 +340,7 @@ describe("SignalArray", function () {
     });
 
     test("values", () => {
-      let arr = new SignalArray([1, 2, 3]);
+      let arr = new SignalArray(1, 2, 3);
       let iter = arr.values();
 
       assert.equal(iter.next().value, 1);
@@ -412,7 +412,7 @@ describe("SignalArray", function () {
       reactivityTest(
         `${method} individual index`,
         class State {
-          arr = new SignalArray(["foo", "bar"]);
+          arr = new SignalArray("foo", "bar");
 
           get value() {
             // @ts-ignore -- this can't be represented easily in TS, and we
@@ -431,7 +431,7 @@ describe("SignalArray", function () {
       reactivityTest(
         `${method} collection tag`,
         class State {
-          arr = new SignalArray(["foo", "bar"]);
+          arr = new SignalArray("foo", "bar");
 
           get value() {
             // @ts-ignore -- this can't be represented easily in TS, and we
@@ -452,7 +452,7 @@ describe("SignalArray", function () {
       reactivityTest(
         `${method} individual index`,
         class {
-          arr = new SignalArray(["foo", "bar"]);
+          arr = new SignalArray("foo", "bar");
 
           get value() {
             return this.arr[0];
@@ -469,7 +469,7 @@ describe("SignalArray", function () {
       reactivityTest(
         `${method} collection tag`,
         class {
-          arr = new SignalArray(["foo", "bar"]);
+          arr = new SignalArray("foo", "bar");
 
           get value() {
             return this.arr.forEach(() => {
@@ -485,5 +485,25 @@ describe("SignalArray", function () {
         },
       );
     });
+  });
+
+  test("is subclassable", () => {
+    class MyArray extends SignalArray<number> {
+      constructor(...args: number[]) {
+        super(...args);
+      }
+
+      sayHello() {
+        return "hello";
+      }
+    }
+
+    let arr = new MyArray(1, 2, 3);
+
+    assert.equal(arr.length, 3);
+    assert.equal(arr[0], 1);
+    assert.equal(arr[1], 2);
+    assert.equal(arr[2], 3);
+    assert.equal(arr.sayHello(), "hello");
   });
 });


### PR DESCRIPTION
Fixes #96 

I'm not sure if you want to accept this, but I wanted to see what it would take. This problem with subclassing is that the SignalArray constructor was passing an entirely unrelated object as the proxy target, and then using that target for property lookups, which wouldn't have any subclass methods on it.

By making SignalArray extend Array `this` can now be the proxy target, and subclass methods are available.

This PR also changes the SignalArray constructor to match Array, since Array calls back into the subclass constructor for some internal methods like `concat()` and passes a number, not an contents array. It was easier this way, but it's a breaking change. We could also make `new SignalArray()` accept a length parameter.

Another result of this is that methods like `concat()` _do_ return a new SignalArray instance now, instead of a plain Array.

Accepting this probably depends on #95 being answered, since we'd now have a proxy and a subclass.